### PR TITLE
Fix dev environment search

### DIFF
--- a/src/main/java/joshie/enchiridion/designer/BookRegistry.java
+++ b/src/main/java/joshie/enchiridion/designer/BookRegistry.java
@@ -124,7 +124,7 @@ public class BookRegistry {
     }
 
     public static void registerModInDev(String modid, File source) {
-        File path = FileHelper.getDevAssetsForModPath(source.getParentFile(), modid, "books");
+        File path = FileHelper.getDevAssetsForModPath(source, modid, "books");
         if (!path.exists()) {
             path.mkdir();
         }


### PR DESCRIPTION
File search is 1 directory off then using IDEA launch because of getParentFile(). When using gradle launch, mod is in .jar file, so removing getParentFile() will not cause problems with that.