### PR TITLE
Fix for NoSuchFieldError: BOOKS on servers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ minecraft {
 dependencies {
     deobfCompile "mezz.jei:jei_${minecraft_version}:${jei_version}:api"
     runtime "mezz.jei:jei_${minecraft_version}:${jei_version}"
-    deobfCompile "info.amerifrance.guideapi:Guide-API:1.11-${guideapi_version}"
+    deobfCompile "info.amerifrance.guideapi:Guide-API:1.11.2-${guideapi_version}"
     //deobfCompile "MineTweaker3:MineTweaker3-API:${minetweaker_version}"
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 minecraft_version=1.11.2
-forge_version=13.20.0.2223
+forge_version=13.20.0.2315
 mappings_version=snapshot_20161220
-mod_version=3.1.17
-jei_version=4.2.4.226
-guideapi_version=2.1.0-47
+mod_version=3.1.18
+jei_version=4.5.0.289
+guideapi_version=2.1.1-52
 minetweaker_version=3.0.14.59

--- a/src/main/java/joshie/enchiridion/gui/config/GuiFactory.java
+++ b/src/main/java/joshie/enchiridion/gui/config/GuiFactory.java
@@ -6,7 +6,7 @@ import net.minecraftforge.fml.client.IModGuiFactory;
 
 import java.util.Set;
 
-public class GuiFactory implements IModGuiFactory {
+public abstract class GuiFactory implements IModGuiFactory {
 
     @Override
     public void initialize(Minecraft minecraftInstance) {

--- a/src/main/java/joshie/enchiridion/library/ModSupport.java
+++ b/src/main/java/joshie/enchiridion/library/ModSupport.java
@@ -55,7 +55,7 @@ public class ModSupport {
         books.add("switchclick", "rftoolsdim:rftoolsdim_manual", false, false);
         books.add("switchclick", "theoneprobe:probenote", false, false);
         if (EInfo.IS_GUIDEAPI_LOADED) {
-            for (Book book : GuideAPI.BOOKS) {
+            for (Book book : GuideAPI.getBooks().values()) {
                 books.add("copynbt", "guideapi:" + book.getRegistryName().toString().replace(":", "-"), false, false);
             }
         }


### PR DESCRIPTION
I updated the dependencies of Guide-API, JEI, and Forge to 1.11.2-2.1.1-52, 4.5.0.289, and 13.20.0.2315 respectively. I started the server in IntelliJ and it let me know what the issues were, and then managed to fix how it gets the books from GuideAPI (main issue), and it said that the class GuiFactory needed to be abstract in order to implement IModGuiFactory. 

I have tested the server and client with Creating a book, editing a book, and opening the library. No issues occured.

(This is also my first ever Pull Request. Lets hope I helped someone out.)